### PR TITLE
Introducing Subject in GitHubSource and repurposing Source

### DIFF
--- a/cmd/github_receive_adapter/main.go
+++ b/cmd/github_receive_adapter/main.go
@@ -122,5 +122,6 @@ func main() {
 
 		ra.HandleEvent(event, r.Header)
 	})
-	http.ListenAndServe(fmt.Sprintf(":%s", port), nil)
+	addr := fmt.Sprintf(":%s", port)
+	http.ListenAndServe(addr, nil)
 }

--- a/cmd/github_receive_adapter/main.go
+++ b/cmd/github_receive_adapter/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -121,5 +122,5 @@ func main() {
 
 		ra.HandleEvent(event, r.Header)
 	})
-	http.ListenAndServe(port, nil)
+	http.ListenAndServe(fmt.Sprintf(":%s", port), nil)
 }

--- a/cmd/github_receive_adapter/main.go
+++ b/cmd/github_receive_adapter/main.go
@@ -32,6 +32,9 @@ const (
 
 	// Environment variable containing GitHub secret token
 	envSecret = "GITHUB_SECRET_TOKEN"
+
+	// Environment variable containing information about the source of the event.
+	envOwnerRepo = "GITHUB_OWNER_REPO"
 )
 
 var validEvents = []gh.Event{
@@ -91,9 +94,14 @@ func main() {
 		log.Fatalf("No secret token given")
 	}
 
-	log.Printf("Sink is: %q", *sink)
+	ownerRepo := os.Getenv(envOwnerRepo)
+	if ownerRepo == "" {
+		log.Fatalf("No ownerRepo given")
+	}
 
-	ra, err := github.New(*sink)
+	log.Printf("Sink is: %q, OwnerRepo is: %q", *sink, ownerRepo)
+
+	ra, err := github.New(*sink, ownerRepo)
 	if err != nil {
 		log.Fatalf("Failed to create github adapter: %s", err.Error())
 	}

--- a/pkg/adapter/github/adapter.go
+++ b/pkg/adapter/github/adapter.go
@@ -51,7 +51,10 @@ func New(sinkURI, ownerRepo string) (*Adapter, error) {
 	if err != nil {
 		return nil, err
 	}
-	// set the CloudEvent source.
+	// Set the CloudEvent source. This will be the same for all CloudEvents emitted
+	// from this adapter. This is needed to simplify the instantiation of EventTypes
+	// in the GitHubSource controller.
+	// What we generate dynamically is the CloudEvent subject.
 	a.source = types.ParseURLRef(fmt.Sprintf("/%s", ownerRepo))
 	if a.source == nil {
 		return nil, fmt.Errorf("invalid source %q", ownerRepo)

--- a/pkg/adapter/github/adapter.go
+++ b/pkg/adapter/github/adapter.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strings"
 
 	"github.com/cloudevents/sdk-go/pkg/cloudevents"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/client"
@@ -38,17 +39,24 @@ const (
 // Adapter converts incoming GitHub webhook events to CloudEvents
 type Adapter struct {
 	client client.Client
+	source *types.URLRef
 }
 
 // New creates an adapter to convert incoming GitHub webhook events to CloudEvents and
 // then sends them to the specified Sink
-func New(sinkURI string) (*Adapter, error) {
+func New(sinkURI, ownerRepo string) (*Adapter, error) {
 	a := new(Adapter)
 	var err error
 	a.client, err = kncloudevents.NewDefaultClient(sinkURI)
 	if err != nil {
 		return nil, err
 	}
+	// set the CloudEvent source.
+	source := types.ParseURLRef(fmt.Sprintf("/%s", ownerRepo))
+	if source == nil {
+		return nil, fmt.Errorf("invalid source %q", ownerRepo)
+	}
+	a.source = source
 	return a, nil
 }
 
@@ -72,133 +80,185 @@ func (a *Adapter) handleEvent(payload interface{}, hdr http.Header) error {
 	log.Printf("Handling %s", gitHubEventType)
 
 	cloudEventType := fmt.Sprintf("%s.%s", sourcesv1alpha1.GitHubSourceEventPrefix, gitHubEventType)
-	source, err := sourceFromGitHubEvent(gh.Event(gitHubEventType), payload)
-	if err != nil {
-		return err
-	}
+	subject := subjectFromGitHubEvent(gh.Event(gitHubEventType), payload)
+
+	eventContext := cloudevents.EventContextV02{
+		ID:         eventID,
+		Type:       cloudEventType,
+		Source:     *a.source,
+		Extensions: extensions,
+	}.AsV02()
+	eventContext.SetSubject(subject)
 
 	event := cloudevents.Event{
-		Context: cloudevents.EventContextV02{
-			ID:         eventID,
-			Type:       cloudEventType,
-			Source:     *source,
-			Extensions: extensions,
-		}.AsV02(),
-		Data: payload,
+		Context: eventContext,
+		Data:    payload,
 	}
-	_, err = a.client.Send(context.TODO(), event)
+	_, err := a.client.Send(context.TODO(), event)
 	return err
 }
 
-func sourceFromGitHubEvent(gitHubEvent gh.Event, payload interface{}) (*types.URLRef, error) {
-	var url string
+func subjectFromGitHubEvent(gitHubEvent gh.Event, payload interface{}) string {
+	var subject string
 	switch gitHubEvent {
 	case gh.CheckSuiteEvent:
-		cs := payload.(gh.CheckSuitePayload)
-		url = cs.Repository.HTMLURL
+		if cs, ok := payload.(gh.CheckSuitePayload); ok {
+			subject = string(cs.CheckSuite.ID)
+		}
 	case gh.CommitCommentEvent:
-		cc := payload.(gh.CommitCommentPayload)
-		url = cc.Comment.HTMLURL
+		if cc, ok := payload.(gh.CommitCommentPayload); ok {
+			// E.g., https://github.com/Codertocat/Hello-World/commit/a10867b14bb761a232cd80139fbd4c0d33264240#commitcomment-29186860
+			// and we keep with a10867b14bb761a232cd80139fbd4c0d33264240#commitcomment-29186860
+			subject = lastPathPortion(cc.Comment.HTMLURL)
+		}
 	case gh.CreateEvent:
-		c := payload.(gh.CreatePayload)
-		url = c.Repository.HTMLURL
+		if c, ok := payload.(gh.CreatePayload); ok {
+			// The object that was created, can be repository, branch, or tag.
+			subject = c.RefType
+		}
 	case gh.DeleteEvent:
-		d := payload.(gh.DeletePayload)
-		url = d.Repository.HTMLURL
+		if d, ok := payload.(gh.DeletePayload); ok {
+			// The object that was deleted, can be branch or tag.
+			subject = d.RefType
+		}
 	case gh.DeploymentEvent:
-		d := payload.(gh.DeploymentPayload)
-		url = d.Repository.HTMLURL
+		if d, ok := payload.(gh.DeploymentPayload); ok {
+			subject = string(d.Deployment.ID)
+		}
 	case gh.DeploymentStatusEvent:
-		d := payload.(gh.DeploymentStatusPayload)
-		url = d.Repository.HTMLURL
+		if d, ok := payload.(gh.DeploymentStatusPayload); ok {
+			subject = string(d.Deployment.ID)
+		}
 	case gh.ForkEvent:
-		f := payload.(gh.ForkPayload)
-		url = f.Forkee.HTMLURL
+		if f, ok := payload.(gh.ForkPayload); ok {
+			subject = string(f.Forkee.ID)
+		}
 	case gh.GollumEvent:
-		g := payload.(gh.GollumPayload)
-		url = g.Repository.HTMLURL
+		if g, ok := payload.(gh.GollumPayload); ok {
+			pages := make([]string, 0, len(g.Pages))
+			for _, page := range g.Pages {
+				pages = append(pages, page.PageName)
+			}
+			subject = strings.Join(pages, ",")
+		}
 	case gh.InstallationEvent, gh.IntegrationInstallationEvent:
-		i := payload.(gh.InstallationPayload)
-		url = i.Installation.HTMLURL
+		if i, ok := payload.(gh.InstallationPayload); ok {
+			subject = string(i.Installation.ID)
+		}
 	case gh.IssueCommentEvent:
-		i := payload.(gh.IssueCommentPayload)
-		url = i.Comment.HTMLURL
+		if i, ok := payload.(gh.IssueCommentPayload); ok {
+			// E.g., https://github.com/Codertocat/Hello-World/issues/2#issuecomment-393304133
+			// and we keep with 2#issuecomment-393304133
+			subject = lastPathPortion(i.Comment.HTMLURL)
+		}
 	case gh.IssuesEvent:
-		i := payload.(gh.IssuesPayload)
-		url = i.Issue.HTMLURL
+		if i, ok := payload.(gh.IssuesPayload); ok {
+			subject = string(i.Issue.Number)
+		}
 	case gh.LabelEvent:
-		l := payload.(gh.LabelPayload)
-		url = l.Repository.HTMLURL
+		if l, ok := payload.(gh.LabelPayload); ok {
+			// E.g., :bug: Bugfix
+			subject = l.Label.Name
+		}
 	case gh.MemberEvent:
-		m := payload.(gh.MemberPayload)
-		url = m.Repository.HTMLURL
+		if m, ok := payload.(gh.MemberPayload); ok {
+			subject = string(m.Member.ID)
+		}
 	case gh.MembershipEvent:
-		m := payload.(gh.MembershipPayload)
-		url = m.Organization.URL
+		if m, ok := payload.(gh.MembershipPayload); ok {
+			subject = string(m.Member.ID)
+		}
 	case gh.MilestoneEvent:
-		m := payload.(gh.MilestonePayload)
-		url = m.Repository.HTMLURL
+		if m, ok := payload.(gh.MilestonePayload); ok {
+			subject = string(m.Milestone.Number)
+		}
 	case gh.OrganizationEvent:
-		o := payload.(gh.OrganizationPayload)
-		url = o.Organization.URL
+		if o, ok := payload.(gh.OrganizationPayload); ok {
+			// The action that was performed, can be member_added, member_removed, or member_invited.
+			subject = o.Action
+		}
 	case gh.OrgBlockEvent:
-		o := payload.(gh.OrgBlockPayload)
-		url = o.Organization.URL
+		if o, ok := payload.(gh.OrgBlockPayload); ok {
+			// The action performed, can be blocked or unblocked.
+			subject = o.Action
+		}
 	case gh.PageBuildEvent:
-		p := payload.(gh.PageBuildPayload)
-		url = p.Repository.HTMLURL
+		if p, ok := payload.(gh.PageBuildPayload); ok {
+			subject = string(p.ID)
+		}
 	case gh.PingEvent:
-		p := payload.(gh.PingPayload)
-		url = p.Hook.Config.URL
+		if p, ok := payload.(gh.PingPayload); ok {
+			subject = string(p.HookID)
+		}
 	case gh.ProjectCardEvent:
-		p := payload.(gh.ProjectCardPayload)
-		url = p.Repository.HTMLURL
+		if p, ok := payload.(gh.ProjectCardPayload); ok {
+			// The action performed on the project card, can be created, edited, moved, converted, or deleted.
+			subject = p.Action
+		}
 	case gh.ProjectColumnEvent:
-		p := payload.(gh.ProjectColumnPayload)
-		url = p.Repository.HTMLURL
+		if p, ok := payload.(gh.ProjectColumnPayload); ok {
+			// The action performed on the project column, can be created, edited, moved, converted, or deleted.
+			subject = p.Action
+		}
 	case gh.ProjectEvent:
-		p := payload.(gh.ProjectPayload)
-		url = p.Repository.HTMLURL
+		if p, ok := payload.(gh.ProjectPayload); ok {
+			// The action that was performed on the project, can be created, edited, closed, reopened, or deleted.
+			subject = p.Action
+		}
 	case gh.PublicEvent:
-		p := payload.(gh.PublicPayload)
-		url = p.Repository.HTMLURL
+		if p, ok := payload.(gh.PublicPayload); ok {
+			subject = string(p.Repository.ID)
+		}
 	case gh.PullRequestEvent:
-		p := payload.(gh.PullRequestPayload)
-		url = p.PullRequest.HTMLURL
+		if p, ok := payload.(gh.PullRequestPayload); ok {
+			subject = string(p.PullRequest.Number)
+		}
 	case gh.PullRequestReviewEvent:
-		p := payload.(gh.PullRequestReviewPayload)
-		url = p.Review.HTMLURL
+		if p, ok := payload.(gh.PullRequestReviewPayload); ok {
+			subject = string(p.Review.ID)
+		}
 	case gh.PullRequestReviewCommentEvent:
-		p := payload.(gh.PullRequestReviewCommentPayload)
-		url = p.Comment.HTMLURL
+		if p, ok := payload.(gh.PullRequestReviewCommentPayload); ok {
+			subject = string(p.Comment.ID)
+		}
 	case gh.PushEvent:
-		p := payload.(gh.PushPayload)
-		url = p.Compare
+		if p, ok := payload.(gh.PushPayload); ok {
+			subject = fmt.Sprintf("%s...%s", p.Before, p.After)
+		}
 	case gh.ReleaseEvent:
-		r := payload.(gh.ReleasePayload)
-		url = r.Release.HTMLURL
+		if r, ok := payload.(gh.ReleasePayload); ok {
+			subject = r.Release.TagName
+		}
 	case gh.RepositoryEvent:
-		r := payload.(gh.RepositoryPayload)
-		url = r.Repository.HTMLURL
+		if r, ok := payload.(gh.RepositoryPayload); ok {
+			subject = string(r.Repository.ID)
+		}
 	case gh.StatusEvent:
-		s := payload.(gh.StatusPayload)
-		url = s.Commit.HTMLURL
+		if s, ok := payload.(gh.StatusPayload); ok {
+			subject = s.Sha
+		}
 	case gh.TeamEvent:
-		t := payload.(gh.TeamPayload)
-		url = t.Organization.URL
+		if t, ok := payload.(gh.TeamPayload); ok {
+			subject = string(t.Team.ID)
+		}
 	case gh.TeamAddEvent:
-		t := payload.(gh.TeamAddPayload)
-		url = t.Repository.HTMLURL
+		if t, ok := payload.(gh.TeamAddPayload); ok {
+			subject = string(t.Repository.ID)
+		}
 	case gh.WatchEvent:
-		w := payload.(gh.WatchPayload)
-		url = w.Repository.HTMLURL
-	}
-	if url != "" {
-		source := types.ParseURLRef(url)
-		if source != nil {
-			return source, nil
+		if w, ok := payload.(gh.WatchPayload); ok {
+			subject = string(w.Repository.ID)
 		}
 	}
+	return subject
+}
 
-	return nil, fmt.Errorf("no source found in github event")
+func lastPathPortion(url string) string {
+	var subject string
+	index := strings.LastIndex(url, "/")
+	if index != -1 {
+		// Keep the last part.
+		subject = url[index+1:]
+	}
+	return subject
 }

--- a/pkg/adapter/github/adapter.go
+++ b/pkg/adapter/github/adapter.go
@@ -137,6 +137,8 @@ func subjectFromGitHubEvent(gitHubEvent gh.Event, payload interface{}) string {
 		}
 	case gh.GollumEvent:
 		if g, ok := payload.(gh.GollumPayload); ok {
+			// The pages that were updated.
+			// E.g., Home
 			pages := make([]string, 0, len(g.Pages))
 			for _, page := range g.Pages {
 				pages = append(pages, page.PageName)
@@ -225,6 +227,10 @@ func subjectFromGitHubEvent(gitHubEvent gh.Event, payload interface{}) string {
 		}
 	case gh.PushEvent:
 		if p, ok := payload.(gh.PushPayload); ok {
+			// This is the last portion of the URL we where retrieving.
+			// E.g., https://github.com/Codertocat/Hello-World/compare/a10867b14bb7...000000000000
+			// and we keep with a10867b14bb7...000000000000. No need to parse the URL as the info is
+			// in available in separate fields.
 			subject = fmt.Sprintf("%s...%s", p.Before, p.After)
 		}
 	case gh.ReleaseEvent:

--- a/pkg/adapter/github/adapter.go
+++ b/pkg/adapter/github/adapter.go
@@ -52,11 +52,10 @@ func New(sinkURI, ownerRepo string) (*Adapter, error) {
 		return nil, err
 	}
 	// set the CloudEvent source.
-	source := types.ParseURLRef(fmt.Sprintf("/%s", ownerRepo))
-	if source == nil {
+	a.source = types.ParseURLRef(fmt.Sprintf("/%s", ownerRepo))
+	if a.source == nil {
 		return nil, fmt.Errorf("invalid source %q", ownerRepo)
 	}
-	a.source = source
 	return a, nil
 }
 

--- a/pkg/reconciler/githubsource/resources/service.go
+++ b/pkg/reconciler/githubsource/resources/service.go
@@ -41,6 +41,10 @@ func MakeService(source *sourcesv1alpha1.GitHubSource, receiveAdapterImage strin
 			},
 		},
 		{
+			Name:  "GITHUB_OWNER_REPO",
+			Value: source.Spec.OwnerAndRepository,
+		},
+		{
 			Name:  "SINK",
 			Value: sinkURI,
 		},


### PR DESCRIPTION
## Proposed Changes

  * Set the CloudEvent source in the receive adapter to be the same across all CloudEvents emitted from this adapter. Same thing is done in AWS SQS, CronJob, etc. And we should do that in the rest as well.
  * This is needed to simplify the instantiation of EventTypes in the Controller (the GitHubSource controller in this case). Otherwise, we will be hardcoding things like `https://github.com/<owner>/<repo>/pull`, `https://apis.github.com/<repository>`, etc., as most of the events have different definitions of the source.   
* Instead of source, we dynamically generate the CloudEvent subject. The decision of what to use as subject is somewhat arbitrary (same as with the previous source).
* This is a breaking change in the sense that if there are consumers that have triggers for a particular CloudEvent source, then they will stop working. As far as I can tell, as the current source has dynamic generated data, e.g.,  https://github.com/nachocano/eventing/pull/<pull_id>, there shouldn't be many triggers out there that currently use the field.  
  
**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note

```