### PR TITLE
Add event resources RBAC

### DIFF
--- a/kafka/channel/config/200-dispatcher-clusterrole.yaml
+++ b/kafka/channel/config/200-dispatcher-clusterrole.yaml
@@ -42,3 +42,11 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - "" # Core API Group.
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+      - update


### PR DESCRIPTION
fixes message delivery on the kafka channel